### PR TITLE
Feature/several start end points

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ repos:
         language: system
         types: [python]
         require_serial: true
-        args: [--quiet, --target-version, py312]
+        args: [--quiet, --target-version, py311]
 
       - id: python-ruff
         name: Ruff linting

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,19 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](https://semver.org/).
 
+## [1.3.2] - 2026-05-08
+
+### Added
+- Multi-pair start/end labelling for closed splines: double-clicking a knot point on a finalized closed spline shows a QMenu popup ("Mark as Start", "Mark as End", "Remove Label"), allowing any number of start/end pairs to be assigned on the same contour
+- Per-pair dotted closure arcs: each matched (start, end) pair renders a solid lesion arc and a complementary dotted closure arc with no visual overlap; additional pairs are composited via a boolean point mask so the solid and dotted paths are always strictly non-overlapping
+
+### Changed
+- Open splines now auto-assign start/end coordinates to the first and last knot point on finalization; no user interaction required
+- `Contour.start_coords` / `end_coords` schema changed from a single `(x, y)` tuple per contour index to a `List[Tuple[float, float]]`; old JSON files are transparently migrated on load via `_normalize_coord_entry`
+
+### Fixed
+- Open spline double-click correctly ends the contour at the double-click position (spurious preceding `mousePressEvent` knot intentionally kept in geometry so `full_contour[-1]` snaps to the click location)
+
 ## [1.3.1] - 2026-05-06
 
 ### Added

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -33,10 +33,10 @@
 - [] Ensure that only tagged frames can be exported
 - [x] Adjust output nifti to work with several contour_types
 - [] Aim for a first test data set including lumen, side branch, catheter for around 300 frames
-- [] Image quality should be tagged
 - [x] Number of interactive points should adjust by circumference of the contour -> make half for smaller contours
-- [] Find a solution to have several section with start end point
-- [] Make mask live update, allow brush mode in mask mode
+- [x] Find a solution to have several sections with start end point
+- [x] Make mask live update, 
+- [] Allow brush mode in mask mode
 
 # Bugs
 - [x] When EEM is present together with lumen the wrong metric is projected to longitudinal view (addition?)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "aivus"
-version = "1.3.1"
+version = "1.3.2"
 description = "AIVUS: AIVUS-CAA (coronary artery anomalies) AIVUS-OCT (optical coherence tomography)"
 authors = ["yungselm", "cardionaut", "Pooya Mohammadi Kazaj"]
 

--- a/src/gui/left_half/display.py
+++ b/src/gui/left_half/display.py
@@ -7,10 +7,9 @@ from typing import Tuple, List, Union, Any
 
 import numpy as np
 from loguru import logger
-from PyQt6.QtWidgets import QGraphicsView, QGraphicsScene, QGraphicsPixmapItem, QGraphicsTextItem
+from PyQt6.QtWidgets import QGraphicsView, QGraphicsScene, QGraphicsPixmapItem, QGraphicsTextItem, QMenu
 from PyQt6.QtCore import Qt, QLineF, QPointF
 from PyQt6.QtGui import QPixmap, QImage
-from shapely.geometry import Polygon
 
 from gui.utils.geometry import Point, Spline, SplineGeometry, OpenSplineGeometry, OpenSpline, get_qt_pen
 from gui.utils.metrics import MetricsMixin
@@ -164,7 +163,9 @@ class Display(QGraphicsView, MetricsMixin):
                 point_thickness=self.point_thickness,
                 alpha=self.alpha_contour,
                 n_points_contour=self.n_points_contour,
-                n_interactive_points=self.n_interactive_points if ct in (ContourType.LUMEN, ContourType.EEM) else self.n_interactive_points // 2,
+                n_interactive_points=self.n_interactive_points
+                if ct in (ContourType.LUMEN, ContourType.EEM)
+                else self.n_interactive_points // 2,
             )
 
         # scene data
@@ -201,7 +202,7 @@ class Display(QGraphicsView, MetricsMixin):
         self._contour_close_committed: bool = False
         self.mask_mode: bool = False
         self.active_point: Point = None
-        self.active_end_coords_flag = True  # Flag to switch, which point double click sets
+        self._active_start_end_idx: int | None = None  # index in start/end list of the dragged labeled point
 
         #####################################################################################################
         # legacy to be refactored
@@ -264,13 +265,13 @@ class Display(QGraphicsView, MetricsMixin):
         """
         Draw contour_data for the specified contour_type.
         - If set_current is True, this spline becomes self.working_spline (editing target).
-        - If contour_type == ContourType.LUMEN also set self.lumen_spline for metrics.
         """
         if not contour_data or not contour_data[0] or not contour_data[1]:
             return
 
-        lumen_x = [point * self.scaling_factor for point in contour_data[0]]
-        lumen_y = [point * self.scaling_factor for point in contour_data[1]]
+        sf = self.scaling_factor
+        lumen_x = [point * sf for point in contour_data[0]]
+        lumen_y = [point * sf for point in contour_data[1]]
 
         ct = contour_type
         cfg = self.contour_configs.get(ct, None)
@@ -281,39 +282,39 @@ class Display(QGraphicsView, MetricsMixin):
         key = self.contour_key(ct)
         fd = self.main_window.data.get(self.frame)
         contour_obj = getattr(fd, key, None) if fd else None
-        raw_start = (
+
+        # Read start/end as lists-of-tuples (new schema).
+        raw_starts = (
             contour_obj.start_coords[contour_index]
             if (contour_obj and len(contour_obj.start_coords) > contour_index)
-            else None
+            else []
         )
-        raw_end = (
+        raw_ends = (
             contour_obj.end_coords[contour_index]
             if (contour_obj and len(contour_obj.end_coords) > contour_index)
-            else None
+            else []
         )
-
-        start_coords = (raw_start[0] * self.scaling_factor, raw_start[1] * self.scaling_factor) if raw_start else None
-        end_coords = (raw_end[0] * self.scaling_factor, raw_end[1] * self.scaling_factor) if raw_end else None
-
-        if start_coords is None and lumen_x:
-            start_coords = (lumen_x[0], lumen_y[0])
 
         is_closed = (
             contour_obj.closed[contour_index] if (contour_obj and len(contour_obj.closed) > contour_index) else True
         )
 
         if is_closed:
-            geometry = SplineGeometry(
-                lumen_x,
-                lumen_y,
-                self.n_points_contour,
-                start_coords,
-                end_coords,
-            )
-            geometry._ensure_start_end_coords()
-            geometry.interpolate()
+            # Closed spline: start/end are user-labelled lists; geometry needs none.
+            start_coords_list = [(x * sf, y * sf) for x, y in raw_starts]
+            end_coords_list = [(x * sf, y * sf) for x, y in raw_ends]
+
+            geometry = SplineGeometry(lumen_x, lumen_y, self.n_points_contour, None, None)
             spline_cls = Spline
         else:
+            # Open spline: single auto start (first knot) / end (last knot).
+            start_coords = (
+                (raw_starts[0][0] * sf, raw_starts[0][1] * sf)
+                if raw_starts
+                else ((lumen_x[0], lumen_y[0]) if lumen_x else None)
+            )
+            end_coords = (raw_ends[0][0] * sf, raw_ends[0][1] * sf) if raw_ends else None
+
             geometry = OpenSplineGeometry(
                 knot_points_x=lumen_x,
                 knot_points_y=lumen_y,
@@ -332,12 +333,26 @@ class Display(QGraphicsView, MetricsMixin):
                 curr_y = geometry.knot_points_y[i]
                 knot_color = color
                 brush = False
-                if start_coords and math.hypot(curr_x - start_coords[0], curr_y - start_coords[1]) < SENSITIVITY:
-                    knot_color = self.start_color
-                    brush = True
-                if end_coords and math.hypot(curr_x - end_coords[0], curr_y - end_coords[1]) < SENSITIVITY:
-                    knot_color = self.end_color
-                    brush = True
+                if is_closed:
+                    for sc in start_coords_list:
+                        if math.hypot(curr_x - sc[0], curr_y - sc[1]) < SENSITIVITY:
+                            knot_color = self.start_color
+                            brush = True
+                            break
+                    if not brush:
+                        for ec in end_coords_list:
+                            if math.hypot(curr_x - ec[0], curr_y - ec[1]) < SENSITIVITY:
+                                knot_color = self.end_color
+                                brush = True
+                                break
+                else:
+                    if start_coords and math.hypot(curr_x - start_coords[0], curr_y - start_coords[1]) < SENSITIVITY:
+                        knot_color = self.start_color
+                        brush = True
+                    if end_coords and math.hypot(curr_x - end_coords[0], curr_y - end_coords[1]) < SENSITIVITY:
+                        knot_color = self.end_color
+                        brush = True
+
                 knot_point = Point(
                     (curr_x, curr_y),
                     self.point_thickness,
@@ -352,6 +367,14 @@ class Display(QGraphicsView, MetricsMixin):
             for p in knot_points:
                 self.graphics_scene.addItem(p)
             spline = spline_cls(geometry, color=color, line_thickness=thickness, transparency=alpha)
+
+            # Attach paired start/end coords to closed splines for dotted arc rendering.
+            if is_closed:
+                n_pairs = min(len(start_coords_list), len(end_coords_list))
+                spline.coord_pairs = list(zip(start_coords_list[:n_pairs], end_coords_list[:n_pairs]))
+                if spline.coord_pairs:
+                    spline._rebuild_path()
+
             self.graphics_scene.addItem(spline)
 
             key_str = self.contour_key(ct)
@@ -399,7 +422,9 @@ class Display(QGraphicsView, MetricsMixin):
                 spline_geo = SplineGeometry(
                     knot_points_x=x_coords,
                     knot_points_y=y_coords,
-                    n_interpolated_points=self.n_interactive_points if contour_type in (ContourType.LUMEN, ContourType.EEM) else self.n_interactive_points // 2,
+                    n_interpolated_points=self.n_interactive_points
+                    if contour_type in (ContourType.LUMEN, ContourType.EEM)
+                    else self.n_interactive_points // 2,
                     start_coords=None,
                     end_coords=None,
                 )
@@ -711,14 +736,14 @@ class Display(QGraphicsView, MetricsMixin):
         self.working_spline = None
         self.points_to_draw = []
         self.active_point = None
-        self.active_end_coords_flag = True
+        self._active_start_end_idx = None
         self.main_window.display.setCursor(Qt.CursorShape.CrossCursor)
 
         fd = self.main_window.data[self.frame]
         contour_obj = getattr(fd, key)
         if not append:
             contour_obj.contours = []
-            contour_obj.start_coords = []
+            contour_obj.start_coords = []  # will be populated in stop_contour
             contour_obj.end_coords = []
             contour_obj.closed = []
         self.display_image(update_contours=True)
@@ -825,7 +850,9 @@ class Display(QGraphicsView, MetricsMixin):
                     [self.working_spline.geometry.full_contour[0].tolist()],
                     [self.working_spline.geometry.full_contour[1].tolist()],
                 ),
-                self.n_interactive_points if self.active_contour_type in (ContourType.LUMEN, ContourType.EEM) else self.n_interactive_points // 2,
+                self.n_interactive_points
+                if self.active_contour_type in (ContourType.LUMEN, ContourType.EEM)
+                else self.n_interactive_points // 2,
             )
             key = self.contour_key(self.active_contour_type)
             x_list = [point / self.scaling_factor for point in downsampled[0]]
@@ -834,10 +861,14 @@ class Display(QGraphicsView, MetricsMixin):
             if self.append_contour_mode:
                 contour_obj.contours.append([x_list, y_list])
                 contour_obj.closed.append(True)
+                contour_obj.start_coords.append([])
+                contour_obj.end_coords.append([])
                 self._contour_close_committed = True
             else:
                 contour_obj.contours = [[x_list, y_list]]
                 contour_obj.closed = [True]
+                contour_obj.start_coords = [[]]
+                contour_obj.end_coords = [[]]
 
         self.stop_contour()
 
@@ -845,9 +876,12 @@ class Display(QGraphicsView, MetricsMixin):
         """Finish drawing an open spline on double-click and save it as open (closed=False).
 
         Qt fires a mousePressEvent just before mouseDoubleClickEvent, so one extra point
-        is added at the double-click position. We discard that last point here.
+        is added at the double-click position. We discard that last *visual* Point here
+        but intentionally leave the knot in the geometry: stop_contour snaps
+        xs_sparse_origin[-1] to full_contour[-1], which is that spurious knot — i.e.
+        exactly the double-click position. Removing it from the geometry would shift
+        the saved end one knot earlier.
         """
-        # Remove the spurious last point added by the preceding mousePressEvent
         if self.points_to_draw:
             last_point = self.points_to_draw.pop()
             if last_point.scene() is not None:
@@ -885,7 +919,9 @@ class Display(QGraphicsView, MetricsMixin):
                         [self.working_spline.geometry.full_contour[0].tolist()],
                         [self.working_spline.geometry.full_contour[1].tolist()],
                     ),
-                    self.n_interactive_points if key in (ContourType.LUMEN, ContourType.EEM) else self.n_interactive_points // 2,
+                    self.n_interactive_points
+                    if key in (ContourType.LUMEN, ContourType.EEM)
+                    else self.n_interactive_points // 2,
                 )
                 xs_sparse_origin = [x / self.scaling_factor for x in downsampled[0]]
                 ys_sparse_origin = [y / self.scaling_factor for y in downsampled[1]]
@@ -894,26 +930,23 @@ class Display(QGraphicsView, MetricsMixin):
                     xs_sparse_origin[-1] = self.working_spline.geometry.full_contour[0][-1] / self.scaling_factor
                     ys_sparse_origin[-1] = self.working_spline.geometry.full_contour[1][-1] / self.scaling_factor
 
+                is_open = not self.working_spline.geometry.is_closed
                 if self.append_contour_mode:
                     if not self._contour_close_committed:
                         contour_obj.contours.append([xs_sparse_origin, ys_sparse_origin])
-                    start = self.working_spline.geometry.start_coords
-                    end = self.working_spline.geometry.end_coords
-                    contour_obj.start_coords.append(
-                        (start[0] / self.scaling_factor, start[1] / self.scaling_factor) if start else None
-                    )
-                    contour_obj.end_coords.append(
-                        (end[0] / self.scaling_factor, end[1] / self.scaling_factor) if end else None
-                    )
+                        # start/end already appended by _close_current_spline for closed splines
+                        if is_open:
+                            contour_obj.start_coords.append([(xs_sparse_origin[0], ys_sparse_origin[0])])
+                            contour_obj.end_coords.append([(xs_sparse_origin[-1], ys_sparse_origin[-1])])
                     self.active_contour_index = len(contour_obj.contours) - 1
                 else:
                     contour_obj.contours = [[xs_sparse_origin, ys_sparse_origin]]
-                    start = self.working_spline.geometry.start_coords
-                    end = self.working_spline.geometry.end_coords
-                    if start:
-                        contour_obj.start_coords = [(start[0] / self.scaling_factor, start[1] / self.scaling_factor)]
-                    if end:
-                        contour_obj.end_coords = [(end[0] / self.scaling_factor, end[1] / self.scaling_factor)]
+                    if is_open:
+                        contour_obj.start_coords = [[(xs_sparse_origin[0], ys_sparse_origin[0])]]
+                        contour_obj.end_coords = [[(xs_sparse_origin[-1], ys_sparse_origin[-1])]]
+                    else:
+                        # closed: start/end already set in _close_current_spline
+                        pass
                 lst = self._ensure_finalized_list_for_key(key, self.active_contour_index + 1)
                 lst[self.active_contour_index] = self.working_spline
 
@@ -1169,8 +1202,10 @@ class Display(QGraphicsView, MetricsMixin):
                 is_closed = contour_obj.closed[i] if len(contour_obj.closed) > i else True
                 if is_closed:
                     continue
-                raw_start = contour_obj.start_coords[i] if len(contour_obj.start_coords) > i else None
-                raw_end = contour_obj.end_coords[i] if len(contour_obj.end_coords) > i else None
+                raw_starts = contour_obj.start_coords[i] if len(contour_obj.start_coords) > i else []
+                raw_ends = contour_obj.end_coords[i] if len(contour_obj.end_coords) > i else []
+                raw_start = raw_starts[0] if raw_starts else None
+                raw_end = raw_ends[0] if raw_ends else None
                 if raw_start is None and raw_end is None:
                     continue
 
@@ -1298,16 +1333,45 @@ class Display(QGraphicsView, MetricsMixin):
             self._add_new_point_to_spline(scene_pos)
 
     def _select_existing_point(self, point_item: Point):
-        # self.main_window.display.setCursor(Qt.CursorShape.BlankCursor)  # remove cursor for precise contour changes
-        # https://stackoverflow.com/questions/53627056/how-to-get-cursor-click-position-in-qgraphicsitem-coordinate-system
         try:
             self.active_point_index = self.points_to_draw.index(point_item)
         except ValueError:
-            # Should not happen if point_item belongs to the active spline
             return
         self.active_point = point_item
         point_item.update_color()
         self.working_spline = self.get_current_spline()
+
+        # Record which index in the start/end list this labeled point corresponds to,
+        # so mouseReleaseEvent can update the correct entry after a drag.
+        self._active_start_end_idx = None
+        if point_item.color in (self.start_color, self.end_color):
+            key = self.contour_key(self.active_contour_type)
+            contour_obj = getattr(self.main_window.data[self.frame], key, None)
+            ci = self.active_contour_index
+            if contour_obj:
+                sf = self.scaling_factor
+                px = point_item.x / sf
+                py = point_item.y / sf
+                coord_list = (
+                    (
+                        contour_obj.start_coords[ci]
+                        if point_item.color == self.start_color
+                        else contour_obj.end_coords[ci]
+                    )
+                    if (
+                        ci
+                        < len(
+                            contour_obj.start_coords if point_item.color == self.start_color else contour_obj.end_coords
+                        )
+                    )
+                    else []
+                )
+                best, best_idx = float('inf'), None
+                for j, (cx, cy) in enumerate(coord_list):
+                    d = math.hypot(px - cx, py - cy)
+                    if d < best:
+                        best, best_idx = d, j
+                self._active_start_end_idx = best_idx
 
     def _add_new_point_to_spline(self, pos):
         if not self.working_spline:
@@ -1331,6 +1395,69 @@ class Display(QGraphicsView, MetricsMixin):
         self.graphics_scene.addItem(self.active_point)
         self.active_point.update_color()
 
+    def _get_active_closed_flag(self) -> bool:
+        """Return True when the currently active contour index is a closed spline."""
+        key = self.contour_key(self.active_contour_type)
+        fd = self.main_window.data.get(self.frame)
+        if fd is None:
+            return True
+        contour_obj = getattr(fd, key, None)
+        if contour_obj is None or not contour_obj.closed:
+            return True
+        ci = self.active_contour_index
+        return contour_obj.closed[ci] if ci < len(contour_obj.closed) else True
+
+    def _show_knot_label_popup(self, knot_item: Point, view_pos):
+        """QMenu popup beside a knot point for labelling it as start, end, or neutral."""
+        key = self.contour_key(self.active_contour_type)
+        contour_obj = getattr(self.main_window.data[self.frame], key, None)
+        if contour_obj is None:
+            return
+        ci = self.active_contour_index
+        sf = self.scaling_factor
+        kx = knot_item.x / sf
+        ky = knot_item.y / sf
+
+        starts = contour_obj.start_coords[ci] if ci < len(contour_obj.start_coords) else []
+        ends = contour_obj.end_coords[ci] if ci < len(contour_obj.end_coords) else []
+
+        is_start = any(math.hypot(kx - sx, ky - sy) < SENSITIVITY for sx, sy in starts)
+        is_end = any(math.hypot(kx - ex, ky - ey) < SENSITIVITY for ex, ey in ends)
+
+        menu = QMenu(self)
+        start_action = menu.addAction("Mark as Start")
+        end_action = menu.addAction("Mark as End")
+        menu.addSeparator()
+        neutral_action = menu.addAction("Remove Label")
+
+        # A point cannot be both start and end; only allow labeling unlabeled points.
+        start_action.setEnabled(not is_start and not is_end)
+        end_action.setEnabled(not is_start and not is_end)
+        neutral_action.setEnabled(is_start or is_end)
+
+        action = menu.exec(self.mapToGlobal(view_pos))
+
+        if action == start_action:
+            while len(contour_obj.start_coords) <= ci:
+                contour_obj.start_coords.append([])
+            contour_obj.start_coords[ci].append((kx, ky))
+        elif action == end_action:
+            while len(contour_obj.end_coords) <= ci:
+                contour_obj.end_coords.append([])
+            contour_obj.end_coords[ci].append((kx, ky))
+        elif action == neutral_action:
+            if is_start and ci < len(contour_obj.start_coords):
+                contour_obj.start_coords[ci] = [
+                    s for s in contour_obj.start_coords[ci] if math.hypot(kx - s[0], ky - s[1]) >= SENSITIVITY
+                ]
+            if is_end and ci < len(contour_obj.end_coords):
+                contour_obj.end_coords[ci] = [
+                    e for e in contour_obj.end_coords[ci] if math.hypot(kx - e[0], ky - e[1]) >= SENSITIVITY
+                ]
+
+        if action is not None:
+            self.update_display()
+
     def _delete_point(self, point_item: Point):
         """Removes a knot point from the scene and the data model."""
         try:
@@ -1351,10 +1478,16 @@ class Display(QGraphicsView, MetricsMixin):
                 if len(contour_obj.contours[ci]) > 1:
                     contour_obj.contours[ci][1].pop(idx)
 
+                px = point_item.x / self.scaling_factor
+                py = point_item.y / self.scaling_factor
                 if point_item.color == self.start_color and ci < len(contour_obj.start_coords):
-                    contour_obj.start_coords[ci] = None
+                    contour_obj.start_coords[ci] = [
+                        s for s in contour_obj.start_coords[ci] if math.hypot(px - s[0], py - s[1]) >= SENSITIVITY
+                    ]
                 if point_item.color == self.end_color and ci < len(contour_obj.end_coords):
-                    contour_obj.end_coords[ci] = None
+                    contour_obj.end_coords[ci] = [
+                        e for e in contour_obj.end_coords[ci] if math.hypot(px - e[0], py - e[1]) >= SENSITIVITY
+                    ]
 
         self.display_image(update_contours=True)
 
@@ -1407,34 +1540,26 @@ class Display(QGraphicsView, MetricsMixin):
                 key = self.contour_key(self.active_contour_type)
                 new_pos = (geom.knot_points_x[self.active_point_index], geom.knot_points_y[self.active_point_index])
 
-                if self.active_point.color == self.start_color:
-                    geom.start_coords = new_pos
-                elif self.active_point.color == self.end_color:
-                    geom.end_coords = new_pos
-
                 x_list = [p / self.scaling_factor for p in geom.knot_points_x]
                 y_list = [p / self.scaling_factor for p in geom.knot_points_y]
                 contour_obj = getattr(self.main_window.data[self.frame], key)
                 ci = self.active_contour_index
                 if ci < len(contour_obj.contours):
                     contour_obj.contours[ci] = [x_list, y_list]
-                # Only persist start/end coords when the dragged point is the designated start or end point.
-                # geom.start_coords always has a value (defaults to first knot), so we must not use it
-                # as a condition — that would overwrite start_coords on every ordinary point drag.
-                if self.active_point.color == self.start_color and geom.start_coords:
-                    start_val = (geom.start_coords[0] / self.scaling_factor, geom.start_coords[1] / self.scaling_factor)
-                    if ci < len(contour_obj.start_coords):
-                        contour_obj.start_coords[ci] = start_val
-                    else:
-                        contour_obj.start_coords.append(start_val)
-                if self.active_point.color == self.end_color and geom.end_coords:
-                    end_val = (geom.end_coords[0] / self.scaling_factor, geom.end_coords[1] / self.scaling_factor)
-                    if ci < len(contour_obj.end_coords):
-                        contour_obj.end_coords[ci] = end_val
-                    else:
-                        contour_obj.end_coords.append(end_val)
 
-                mask_active = getattr(self.main_window, 'mask_mode_box', None) and self.main_window.mask_mode_box.isChecked()
+                # Persist the new position of a labeled start/end knot.
+                new_val = (new_pos[0] / self.scaling_factor, new_pos[1] / self.scaling_factor)
+                label_idx = self._active_start_end_idx
+                if self.active_point.color == self.start_color and ci < len(contour_obj.start_coords):
+                    if label_idx is not None and label_idx < len(contour_obj.start_coords[ci]):
+                        contour_obj.start_coords[ci][label_idx] = new_val
+                if self.active_point.color == self.end_color and ci < len(contour_obj.end_coords):
+                    if label_idx is not None and label_idx < len(contour_obj.end_coords[ci]):
+                        contour_obj.end_coords[ci][label_idx] = new_val
+
+                mask_active = (
+                    getattr(self.main_window, 'mask_mode_box', None) and self.main_window.mask_mode_box.isChecked()
+                )
                 self.display_image(update_image=mask_active, update_contours=True)
                 self.active_point_index = None
                 try:
@@ -1445,46 +1570,16 @@ class Display(QGraphicsView, MetricsMixin):
 
     def mouseDoubleClickEvent(self, event):
         if event.button() == Qt.MouseButton.LeftButton:
-            if not self.drawing_mode:
-                pos = self.mapToScene(event.pos())
-                current_spline = self.get_current_spline()
-
-                if current_spline and current_spline.on_path(pos) is not None:
-                    scaled_coords = (pos.x(), pos.y())
-                    orig_coords = (pos.x() / self.scaling_factor, pos.y() / self.scaling_factor)
-
-                    key = self.contour_key(self.active_contour_type)
-                    contour_obj = getattr(self.main_window.data[self.frame], key)
-
-                    ci = self.active_contour_index
-                    if self.active_end_coords_flag:
-                        current_spline.geometry.end_coords = scaled_coords
-                        if ci < len(contour_obj.end_coords):
-                            contour_obj.end_coords[ci] = orig_coords
-                        else:
-                            contour_obj.end_coords.append(orig_coords)
-                    else:
-                        current_spline.geometry.start_coords = scaled_coords
-                        if ci < len(contour_obj.start_coords):
-                            contour_obj.start_coords[ci] = orig_coords
-                        else:
-                            contour_obj.start_coords.append(orig_coords)
-
-                    self.active_end_coords_flag = not self.active_end_coords_flag
-
-                    current_spline.geometry._ensure_start_end_coords()
-                    current_spline._rebuild_path()
-                    self.update_display()
-            else:
+            if self.drawing_mode:
+                # Finish an open spline being drawn (unchanged behaviour).
                 if self.active_segmentation_tool == SegmentationTool.OPEN_SPLINE:
-                    pos = self.mapToScene(event.pos())
-                    if self.working_spline is not None:
-                        self.working_spline.geometry.end_coords = (pos.x(), pos.y())
-                    if self.append_contour_mode:
-                        key = self.contour_key(self.active_contour_type)
-                        contour_obj = getattr(self.main_window.data[self.frame], key)
-                        while len(contour_obj.end_coords) < len(contour_obj.contours):
-                            contour_obj.end_coords.append(None)
                     self._finish_open_spline()
-                    return  # prevent super() re-delivering event after drawing_mode is cleared
+                    return
+            else:
+                # Double-click on a knot point of a closed spline → label popup.
+                items = self.items(event.pos())
+                knot_item = next((i for i in items if isinstance(i, Point) and i in self.points_to_draw), None)
+                if knot_item and self._get_active_closed_flag():
+                    self._show_knot_label_popup(knot_item, event.pos())
+                    return
         super().mouseDoubleClickEvent(event)

--- a/src/gui/shortcuts.py
+++ b/src/gui/shortcuts.py
@@ -1,11 +1,10 @@
 import os
 import time
 import cv2
-import numpy as np
 
 from loguru import logger
 from functools import partial
-from PyQt6.QtGui import QKeySequence, QDesktopServices, QShortcut, QAction
+from PyQt6.QtGui import QKeySequence, QDesktopServices, QShortcut
 from PyQt6.QtWidgets import QApplication
 from PyQt6.QtCore import Qt, QUrl
 
@@ -17,7 +16,6 @@ from input_output.metadata import MetadataWindow
 from input_output.read_image import read_image, read_nifti_mask
 from input_output.contours_io import write_contours, save_gated_images
 from segmentation.save_as_nifti import save_as_nifti
-from segmentation.segment import segment
 from report.report import report
 
 
@@ -56,7 +54,7 @@ def init_menu(main_window):
     file_menu = main_window.menu_bar.addMenu('File')
     open_action = file_menu.addAction('Open File', partial(read_image, main_window))
     open_action.setShortcut('Ctrl+O')
-    mask_action = file_menu.addAction('Open Mask', partial(read_nifti_mask, main_window))
+    file_menu.addAction('Open Mask', partial(read_nifti_mask, main_window))
     file_menu.addSeparator()
     save_contours = file_menu.addAction('Save Contours', partial(write_contours, main_window))
     save_contours.setShortcut('Ctrl+S')
@@ -354,11 +352,11 @@ def delete_contour(main_window):
                 c = contour_obj.contours[ci]
                 xlist = list(c[0]) if c and c[0] else []
                 ylist = list(c[1]) if c and len(c) > 1 else []
-                start = contour_obj.start_coords[ci] if len(contour_obj.start_coords) > ci else None
-                end = contour_obj.end_coords[ci] if len(contour_obj.end_coords) > ci else None
+                start = contour_obj.start_coords[ci] if len(contour_obj.start_coords) > ci else []
+                end = contour_obj.end_coords[ci] if len(contour_obj.end_coords) > ci else []
                 closed = contour_obj.closed[ci] if len(contour_obj.closed) > ci else True
             else:
-                xlist, ylist, start, end, closed = [], [], None, None, True
+                xlist, ylist, start, end, closed = [], [], [], [], True
 
             main_window.tmp_contours[key] = (ci, xlist, ylist, start, end, closed)
 
@@ -398,10 +396,8 @@ def undo_delete(main_window):
                 contour_obj = getattr(fd, key, None)
                 if contour_obj is not None:
                     contour_obj.contours.insert(ci, [xlist, ylist])
-                    if start is not None:
-                        contour_obj.start_coords.insert(ci, start)
-                    if end is not None:
-                        contour_obj.end_coords.insert(ci, end)
+                    contour_obj.start_coords.insert(ci, start)
+                    contour_obj.end_coords.insert(ci, end)
                     contour_obj.closed.insert(ci, closed)
                     main_window.display.active_contour_index = ci
 
@@ -450,5 +446,5 @@ def save_video_pullback(main_window):
     for frame in range(fps * duration):
         out.write(image_stack[frame, :, :])
     out.release()
-    SuccessMessage(main_window, f'Saving video')
+    SuccessMessage(main_window, 'Saving video')
     main_window.status_bar.showMessage(main_window.waiting_status)

--- a/src/gui/utils/geometry.py
+++ b/src/gui/utils/geometry.py
@@ -9,6 +9,7 @@ from PyQt6.QtGui import QPen, QPainterPath, QColor, QBrush
 from dataclasses import dataclass, field
 from typing import Tuple, List, Optional, Any
 
+
 @dataclass
 class SplineGeometry:
     """Pure geometric representation of a spline, no QT dependencies"""
@@ -18,9 +19,7 @@ class SplineGeometry:
     n_interpolated_points: int
     start_coords: Tuple[float, float] | None
     end_coords: Tuple[float, float] | None
-    full_contour: Tuple[List[float], List[float]] = field(
-        default_factory=lambda: ([], [])
-    )
+    full_contour: Tuple[List[float], List[float]] = field(default_factory=lambda: ([], []))
     is_closed: bool = True
     dashed: bool = False
 
@@ -31,14 +30,16 @@ class SplineGeometry:
         if self.is_closed and len(self.knot_points_x) > 0:
             self._ensure_closed()
             self.interpolate()
-    
+
     def __str__(self):
-        return (f"SplineGeometry(knot_points_x={self.knot_points_x}, "
-                f"knot_points_y={self.knot_points_y}, "
-                f"n_interpolated_points={self.n_interpolated_points}, "
-                f"start_coords={self.start_coords}, "
-                f"end_coords={self.end_coords}, "
-                f"is_closed={self.is_closed})")
+        return (
+            f"SplineGeometry(knot_points_x={self.knot_points_x}, "
+            f"knot_points_y={self.knot_points_y}, "
+            f"n_interpolated_points={self.n_interpolated_points}, "
+            f"start_coords={self.start_coords}, "
+            f"end_coords={self.end_coords}, "
+            f"is_closed={self.is_closed})"
+        )
 
     def _ensure_start_end_coords(self):
         """Sync start/end coords with existing knots. Enforces pins exactly."""
@@ -67,21 +68,19 @@ class SplineGeometry:
 
     def _get_closest_knot_index(self, x: float, y: float) -> int:
         """Helper to find which knot index is physically closest to a coordinate."""
-        distances = [np.sqrt((kx - x)**2 + (ky - y)**2) 
-                    for kx, ky in zip(self.knot_points_x, self.knot_points_y)]
+        distances = [np.sqrt((kx - x) ** 2 + (ky - y) ** 2) for kx, ky in zip(self.knot_points_x, self.knot_points_y)]
         return np.argmin(distances)
 
     def _ensure_closed(self):
         """Ensure first and last points match for closed splines."""
-        if (self.knot_points_x[0] != self.knot_points_x[-1] or 
-            self.knot_points_y[0] != self.knot_points_y[-1]):
+        if self.knot_points_x[0] != self.knot_points_x[-1] or self.knot_points_y[0] != self.knot_points_y[-1]:
             self.knot_points_x.append(self.knot_points_x[0])
             self.knot_points_y.append(self.knot_points_y[0])
 
     @classmethod
-    def from_points(cls, points: List[Tuple[float, float]],
-                    n_interpolated_points: int,
-                    is_closed: bool = True) -> 'SplineGeometry':
+    def from_points(
+        cls, points: List[Tuple[float, float]], n_interpolated_points: int, is_closed: bool = True
+    ) -> 'SplineGeometry':
         """Create a spline from a list of (x, y) points."""
         if not points:
             return cls([], [], None, None, n_interpolated_points, is_closed)
@@ -89,12 +88,12 @@ class SplineGeometry:
         return cls(list(x_coords), list(y_coords), None, None, n_interpolated_points, is_closed)
 
     @classmethod
-    def from_arrays(cls, x_coords: List[float], y_coords: List[float],
-                    n_interpolated_points: int,
-                    is_closed: bool = True) -> 'SplineGeometry':
+    def from_arrays(
+        cls, x_coords: List[float], y_coords: List[float], n_interpolated_points: int, is_closed: bool = True
+    ) -> 'SplineGeometry':
         """Create a spline from separate x and y arrays."""
         return cls(list(x_coords), list(y_coords), None, None, n_interpolated_points, is_closed)
-    
+
     def interpolate(self) -> Tuple[np.ndarray, np.ndarray]:
         """
         Interpolate the spline using B-splines.
@@ -107,13 +106,13 @@ class SplineGeometry:
             if n_points < 2:
                 logger.warning(f"Not enough points for spline interpolation: {len(self.knot_points_x)}")
                 return np.array(self.knot_points_x), np.array(self.knot_points_y)
-            
+
             # k is the degree. Cubic is 3. We need m > k.
             # If we have 2 points, k=1 (linear). 3 points, k=2 (quadratic).
             k = min(3, n_points - 1)
 
             points_array = np.array([self.knot_points_x, self.knot_points_y])
-            
+
             tck, u = splprep(points_array, u=None, s=0.0, k=k, per=int(self.is_closed))
 
             u_new = np.linspace(u.min(), u.max(), self.n_interpolated_points)
@@ -121,10 +120,10 @@ class SplineGeometry:
             self.full_contour = (x_new, y_new)
 
             return x_new, y_new
-        except Exception as  e:
+        except Exception as e:
             logger.error(f"Error in spline interpolation: {e}")
             return np.array(self.knot_points_x), np.array(self.knot_points_y)
-        
+
     def insert_point(self, x: float, y: float, insert_idx: Optional[int] = None) -> int:
         """Insert a new point into the spline"""
         is_was_closed = self.is_closed and len(self.knot_points_x) > 1
@@ -142,7 +141,7 @@ class SplineGeometry:
             self._ensure_closed()
 
         return insert_idx
-    
+
     def get_closest_contour_index(self, x: float, y: float, threshold: float = 20.0) -> Optional[int]:
         """
         Logic: Is the mouse (x, y) near the smooth curve?
@@ -150,33 +149,29 @@ class SplineGeometry:
         """
         if not self.full_contour or len(self.full_contour[0]) == 0:
             return None
-        
-        distances = np.sqrt(
-            (self.full_contour[0] - x) ** 2 + 
-            (self.full_contour[1] - y) ** 2
-        )
+
+        distances = np.sqrt((self.full_contour[0] - x) ** 2 + (self.full_contour[1] - y) ** 2)
         min_dist = np.min(distances)
 
         if min_dist < threshold:
             return np.argmin(distances)
         return None
-    
+
     def _find_best_insertion_index(self, path_index: int) -> int:
         """Find the best index to insert a new point based on contour position."""
         if not self.knot_points_x:
             return 0
-        
+
         knot_path_indices = []
         # Use [:-1] if closed to avoid the duplicate end point confusing the search
         search_x = self.knot_points_x[:-1] if self.is_closed else self.knot_points_x
         search_y = self.knot_points_y[:-1] if self.is_closed else self.knot_points_y
 
         for kx, ky in zip(search_x, search_y):
-            dist = np.sqrt((self.full_contour[0] - kx)**2 + (self.full_contour[1] - ky)**2)
+            dist = np.sqrt((self.full_contour[0] - kx) ** 2 + (self.full_contour[1] - ky) ** 2)
             knot_path_indices.append(np.argmin(dist))
 
         # Use bisect to find where the new path_index fits among the knot indices
-        import bisect
         insertion_idx = bisect.bisect_left(knot_path_indices, path_index)
         return insertion_idx
 
@@ -184,26 +179,22 @@ class SplineGeometry:
         """Return a scaled version of the spline."""
         scaled_x = [x * factor for x in self.knot_points_x]
         scaled_y = [y * factor for y in self.knot_points_y]
-        return SplineGeometry(
-            scaled_x, 
-            scaled_y, 
-            self.n_interpolated_points, 
-            self.start_coords,
-            self.end_coords)
-    
+        return SplineGeometry(scaled_x, scaled_y, self.n_interpolated_points, self.start_coords, self.end_coords)
+
     def to_unscaled(self, scaling_factor: float) -> Tuple[List[float], List[float]]:
         """Return unscaled knot points."""
         if self.full_contour is not None:
-            return ([x / scaling_factor for x in self.full_contour[0]],
-                [y / scaling_factor for y in self.full_contour[1]])
+            return (
+                [x / scaling_factor for x in self.full_contour[0]],
+                [y / scaling_factor for y in self.full_contour[1]],
+            )
         else:
-            return ([x / scaling_factor for x in self.knot_points_x],
-                [y / scaling_factor for y in self.knot_points_y])
-        
+            return ([x / scaling_factor for x in self.knot_points_x], [y / scaling_factor for y in self.knot_points_y])
+
     def get_split_interpolated_points(self):
         """Logic: If no end_coords, the whole spline is the 'main' solid segment."""
         full_x, full_y = self.interpolate()
-        
+
         # If no end point is defined, there is no 'tail' (dotted part)
         if self.end_coords is None:
             return (full_x, full_y), (np.array([]), np.array([]))
@@ -211,9 +202,9 @@ class SplineGeometry:
         # Find the index in the interpolated array closest to start and end
         start_idx = 0
         if self.start_coords:
-            start_idx = np.argmin(np.sqrt((full_x - self.start_coords[0])**2 + (full_y - self.start_coords[1])**2))
-            
-        end_idx = np.argmin(np.sqrt((full_x - self.end_coords[0])**2 + (full_y - self.end_coords[1])**2))
+            start_idx = np.argmin(np.sqrt((full_x - self.start_coords[0]) ** 2 + (full_y - self.start_coords[1]) ** 2))
+
+        end_idx = np.argmin(np.sqrt((full_x - self.end_coords[0]) ** 2 + (full_y - self.end_coords[1]) ** 2))
 
         # Rotate the array so it logically begins at the start_idx
         if self.is_closed:
@@ -221,24 +212,18 @@ class SplineGeometry:
             full_y = np.roll(full_y, -start_idx)
             end_idx = (end_idx - start_idx) % len(full_x)
 
-        main_seg = (full_x[:end_idx + 1], full_y[:end_idx + 1])
+        main_seg = (full_x[: end_idx + 1], full_y[: end_idx + 1])
         tail_seg = (full_x[end_idx:], full_y[end_idx:])
-        
+
         return main_seg, tail_seg
 
 
 class Point(QGraphicsEllipseItem):
     """Qt-specific point drawing class - only handles Qt interaction"""
-    
+
     def __init__(
-            self, 
-            pos, 
-            line_thickness=1, 
-            point_radius=10, 
-            index=0, 
-            color=None, 
-            transparency=255,
-            brush: bool = False):
+        self, pos, line_thickness=1, point_radius=10, index=0, color=None, transparency=255, brush: bool = False
+    ):
         super().__init__()
         self.line_thickness = line_thickness
         self.point_radius = point_radius
@@ -246,7 +231,7 @@ class Point(QGraphicsEllipseItem):
         self.color = color
         self.x, self.y = pos[0], pos[1]
         self.index = index
-        
+
         self.default_color = get_qt_pen(color, line_thickness, transparency)
         self.setPen(self.default_color)
 
@@ -257,11 +242,11 @@ class Point(QGraphicsEllipseItem):
             self.default_brush = None
 
         self._update_qt_rect()
-    
+
     def get_coords(self):
         """Get coordinates - simple wrapper for Qt compatibility"""
         return self.x, self.y
-    
+
     def update_pos(self, pos):
         """Update point position from Qt event"""
         if isinstance(pos, QPointF):
@@ -270,21 +255,18 @@ class Point(QGraphicsEllipseItem):
             # Handle case where pos might be a tuple or other type
             self.x, self.y = pos.x(), pos.y() if hasattr(pos, 'x') else pos
         return self._update_qt_rect()
-    
+
     def _update_qt_rect(self):
         """Update Qt rectangle from internal coordinates"""
         self.setRect(
-            self.x - self.point_radius * 0.5,
-            self.y - self.point_radius * 0.5,
-            self.point_radius,
-            self.point_radius
+            self.x - self.point_radius * 0.5, self.y - self.point_radius * 0.5, self.point_radius, self.point_radius
         )
         return self.rect()
-    
+
     def update_color(self):
         """Change appearance when selected"""
         self.setPen(QPen(Qt.GlobalColor.transparent, self.line_thickness))
-    
+
     def reset_color(self):
         """Reset to default appearance"""
         self.setPen(self.default_color)
@@ -294,41 +276,42 @@ class Point(QGraphicsEllipseItem):
 
 class Spline(QGraphicsPathItem):
     """Qt-specific spline drawing class initialized with SplineGeometry"""
-    
-    def __init__(self, 
-                 geometry: SplineGeometry, 
-                 color: Any = "blue", 
-                 line_thickness: int = 1, 
-                 transparency: int = 255):
+
+    def __init__(self, geometry: SplineGeometry, color: Any = "blue", line_thickness: int = 1, transparency: int = 255):
         super().__init__()
         self.geometry = geometry
-        
+        # List of (start_scaled, end_scaled) pairs for closed spline dotted arcs.
+        # Set by display code after construction; each pair produces one dotted closure arc.
+        self.coord_pairs: List[Tuple] = []
+
         self.main_pen = get_qt_pen(color, line_thickness, transparency)
         self.setPen(self.main_pen)
 
-        self.tail_item = QGraphicsPathItem(self) 
         self.tail_pen = get_qt_pen(color, line_thickness, transparency)
         self.tail_pen.setStyle(Qt.PenStyle.DotLine)
-        self.tail_item.setPen(self.tail_pen)
-        
+        # Child items for dotted closure arcs; grown on demand, never shrunk.
+        self._tail_items: List[QGraphicsPathItem] = []
+
         self._rebuild_path()
 
     def __str__(self):
-        return (f"Spline(geometry={self.geometry}, "
-                f"color={self.main_pen.color().name()}, "
-                f"line_thickness={self.main_pen.width()}, "
-                f"transparency={self.main_pen.color().alpha()})")
+        return (
+            f"Spline(geometry={self.geometry}, "
+            f"color={self.main_pen.color().name()}, "
+            f"line_thickness={self.main_pen.width()}, "
+            f"transparency={self.main_pen.color().alpha()})"
+        )
 
     @property
     def full_contours(self) -> Tuple[np.ndarray, np.ndarray]:
         """Compatibility property for existing Display code"""
         return self.geometry.interpolate()
-    
+
     @property
     def knot_points(self) -> Tuple[List[float], List[float]]:
         """Compatibility property for existing Display code"""
         return self.geometry.knot_points_x, self.geometry.knot_points_y
-    
+
     @property
     def full_points(self) -> List[Point]:
         """Get all interpolated points as Qt Point items."""
@@ -363,43 +346,95 @@ class Spline(QGraphicsPathItem):
             new_pen = get_qt_pen(color, pen.width(), pen.color().alpha())
             new_pen.setStyle(pen.style())
             pen = new_pen
-            
+
         self.setPen(pen)
 
     def _rebuild_path(self):
-            """Internal: Rebuild Qt path from the geometry object with dotted 'closure' logic."""
-            # 1. Get the split interpolated points
-            # If end_coords exist, main_seg is start->end, tail_seg is end->start
-            main_seg, tail_seg = self.geometry.get_split_interpolated_points()
-            
-            # --- Handle Main Path (Solid) ---
-            main_path = QPainterPath()
-            if len(main_seg[0]) > 0:
-                main_path.moveTo(QPointF(main_seg[0][0], main_seg[1][0]))
-                for i in range(1, len(main_seg[0])):
-                    main_path.lineTo(QPointF(main_seg[0][i], main_seg[1][i]))
-            
-            self.setPath(main_path)
+        """Rebuild Qt path.
 
-            tail_path = QPainterPath()
-            # Only draw dotted line if we have a tail AND the geometry is meant to be closed
-            if self.geometry.is_closed and len(tail_seg[0]) > 1:
-                tail_path.moveTo(QPointF(tail_seg[0][0], tail_seg[1][0]))
-                for i in range(1, len(tail_seg[0])):
-                    tail_path.lineTo(QPointF(tail_seg[0][i], tail_seg[1][i]))
-                
-                # If the geometry says it's closed but the tail doesn't quite reach 
-                # the start, we can force a closeSubpath or a lineTo start_coords
-                tail_path.lineTo(QPointF(main_seg[0][0], main_seg[1][0]))
-                
-                self.tail_item.setPath(tail_path)
-                self.tail_item.setVisible(True)
+        No coord_pairs: full spline drawn solid (original single-arc behaviour).
+        With coord_pairs: build a boolean mask over the interpolated points to decide
+        which belong to a "lesion" arc (solid) and which belong to a "closure" arc
+        (dotted).  The two paths are strictly non-overlapping so the dotted pen cannot
+        bleed through the solid pen anywhere.  Works for any number of pairs.
+        """
+        full_x, full_y = self.geometry.interpolate()
+
+        for ti in self._tail_items:
+            ti.setVisible(False)
+
+        if not self.coord_pairs or not self.geometry.is_closed:
+            # No pairs: full solid spline (original behaviour).
+            path = QPainterPath()
+            if len(full_x) > 0:
+                path.moveTo(QPointF(float(full_x[0]), float(full_y[0])))
+                for i in range(1, len(full_x)):
+                    path.lineTo(QPointF(float(full_x[i]), float(full_y[i])))
+            self.setPen(self.main_pen)
+            self.setPath(path)
+            return
+
+        n = len(full_x)
+        if n < 2:
+            return
+
+        fx_np = np.asarray(full_x, dtype=float)
+        fy_np = np.asarray(full_y, dtype=float)
+
+        # Build a boolean mask: True = this interpolated point is inside at least one
+        # lesion arc and should be drawn solid.
+        is_solid = np.zeros(n, dtype=bool)
+        for start, end in self.coord_pairs:
+            if start is None or end is None:
+                continue
+            si = int(np.argmin((fx_np - start[0]) ** 2 + (fy_np - start[1]) ** 2))
+            ei = int(np.argmin((fx_np - end[0]) ** 2 + (fy_np - end[1]) ** 2))
+            if si <= ei:
+                is_solid[si : ei + 1] = True
+            else:  # arc wraps around index 0
+                is_solid[si:] = True
+                is_solid[: ei + 1] = True
+
+        # Walk the circle once and emit into the solid or dotted path depending on the
+        # mask.  At each solid↔dotted transition the shared endpoint is added to both
+        # paths so the two arcs meet exactly with no gap.
+        solid_path = QPainterPath()
+        dotted_path = QPainterPath()
+
+        in_solid = bool(is_solid[0])
+        cur = solid_path if in_solid else dotted_path
+        cur.moveTo(QPointF(float(fx_np[0]), float(fy_np[0])))
+
+        for k in range(1, n):
+            next_solid = bool(is_solid[k])
+            if next_solid == in_solid:
+                cur.lineTo(QPointF(float(fx_np[k]), float(fy_np[k])))
             else:
-                self.tail_item.setVisible(False)
+                # Include the transition point in the current segment, then start a
+                # new segment on the other path from the same point.
+                cur.lineTo(QPointF(float(fx_np[k]), float(fy_np[k])))
+                in_solid = next_solid
+                cur = solid_path if in_solid else dotted_path
+                cur.moveTo(QPointF(float(fx_np[k]), float(fy_np[k])))
+
+        # Close the last segment back to the first point.
+        cur.lineTo(QPointF(float(fx_np[0]), float(fy_np[0])))
+
+        # Parent item draws the solid segments.
+        self.setPen(self.main_pen)
+        self.setPath(solid_path)
+
+        # Single child item draws the dotted segments.
+        while len(self._tail_items) < 1:
+            ti = QGraphicsPathItem(self)
+            self._tail_items.append(ti)
+        self._tail_items[0].setPen(self.tail_pen)
+        self._tail_items[0].setPath(dotted_path)
+        self._tail_items[0].setVisible(True)
 
     def update(self, pos: QPointF, index: int, path_index: Optional[int] = None) -> int:
         """
-        Updates the geometry and redraws. 
+        Updates the geometry and redraws.
         Matches the signature Display.mouseMoveEvent expects.
         """
         if path_index is not None:
@@ -422,14 +457,14 @@ class Spline(QGraphicsPathItem):
                 elif index == last_idx:
                     self.geometry.knot_points_x[0] = pos.x()
                     self.geometry.knot_points_y[0] = pos.y()
-                
+
             self._rebuild_path()
             return index
-            
+
     def on_path(self, pos: QPointF) -> Optional[int]:
         """Qt Wrapper for the geometry logic"""
         return self.geometry.get_closest_contour_index(pos.x(), pos.y())
-            
+
     def get_unscaled_contour(self, scaling_factor: float):
         """Compatibility method"""
         return self.geometry.to_unscaled(scaling_factor)
@@ -457,7 +492,7 @@ def get_qt_pen(color, thickness, transparency=255):
     else:
         # Default to blue
         pen_color = QColor(Qt.GlobalColor.blue)
-    
+
     if not isinstance(transparency, int):
         try:
             transparency = int(transparency)
@@ -470,33 +505,29 @@ def get_qt_pen(color, thickness, transparency=255):
 
 class OpenSplineGeometry(SplineGeometry):
     """A SplineGeometry that defaults to is_closed=False"""
-    def __init__(self, knot_points_x, knot_points_y, n_interpolated_points, 
-                 start_coords=None, end_coords=None, dashed=False):
+
+    def __init__(
+        self, knot_points_x, knot_points_y, n_interpolated_points, start_coords=None, end_coords=None, dashed=False
+    ):
         super().__init__(
             knot_points_x=knot_points_x,
             knot_points_y=knot_points_y,
             n_interpolated_points=n_interpolated_points,
             start_coords=start_coords,
             end_coords=end_coords,
-            is_closed=False, # Enforced
-            dashed=dashed
+            is_closed=False,  # Enforced
+            dashed=dashed,
         )
 
 
 class OpenSpline(Spline):
-    """A Spline Item that uses OpenSplineGeometry and ignores 'tail' logic"""
+    """A Spline Item that uses OpenSplineGeometry; no dotted-arc logic."""
+
     def __init__(self, geometry: OpenSplineGeometry, **kwargs):
-        # Force geometry to be open if it isn't already
-        geometry.is_closed = False 
+        geometry.is_closed = False
         super().__init__(geometry, **kwargs)
-        
-        # For open splines, the tail_item is usually unnecessary 
-        # unless you want a dotted preview of a 'potential' closure.
-        self.tail_item.setVisible(False) 
 
     def _rebuild_path(self):
-        """Overrides rebuild to simplify for open paths if needed"""
-        # If it's an open spline, we just draw the main interpolation
         x_new, y_new = self.geometry.interpolate()
         path = QPainterPath()
         if len(x_new) > 0:
@@ -504,4 +535,5 @@ class OpenSpline(Spline):
             for x, y in zip(x_new[1:], y_new[1:]):
                 path.lineTo(QPointF(x, y))
         self.setPath(path)
-        self.tail_item.setVisible(False)
+        for ti in self._tail_items:
+            ti.setVisible(False)

--- a/src/input_output/contours_io.py
+++ b/src/input_output/contours_io.py
@@ -31,8 +31,11 @@ class Contour:
     contours: List[Tuple[List[float], List[float]]] = field(default_factory=list)
     measurements: Measurements = field(default_factory=Measurements)
     closed: List[bool] = field(default_factory=list)
-    start_coords: List[Tuple[Tuple[float, ...], Tuple[float, ...]]] = field(default_factory=list)
-    end_coords: List[Tuple[Tuple[float, ...], Tuple[float, ...]]] = field(default_factory=list)
+    # Each entry is a list of (x, y) tuples for that contour index.
+    # Open splines: always [(first_x, first_y)] / [(last_x, last_y)] (auto-set).
+    # Closed splines: [] initially, grows as user labels knot points.
+    start_coords: List[List[Tuple[float, float]]] = field(default_factory=list)
+    end_coords: List[List[Tuple[float, float]]] = field(default_factory=list)
 
 
 @dataclass
@@ -63,6 +66,32 @@ class FrameData:
 # ---------------------------------------------------------------------------
 # Internal helpers
 # ---------------------------------------------------------------------------
+
+
+def _normalize_coord_entry(item) -> List[Tuple[float, float]]:
+    """Normalize a persisted start/end entry to the new list-of-tuples format.
+
+    Handles three legacy shapes:
+      None                          → []
+      (x, y)  / [x, y]             → [(x, y)]   (old single-point format)
+      [(x, y), ...]                 → [(x, y), ...]  (already new format)
+    """
+    if item is None:
+        return []
+    if isinstance(item, (list, tuple)):
+        if len(item) == 0:
+            return []
+        first = item[0]
+        # Single (x, y) pair stored directly
+        if isinstance(first, (int, float)):
+            return [(float(item[0]), float(item[1]))]
+        # List of points
+        result = []
+        for pt in item:
+            if pt is not None and isinstance(pt, (list, tuple)) and len(pt) >= 2:
+                result.append((float(pt[0]), float(pt[1])))
+        return result
+    return []
 
 
 def _to_serializable(obj):
@@ -122,12 +151,14 @@ def _build_contour(raw: Optional[dict]) -> Contour:
         if x and y and x[0] == x[-1] and y[0] == y[-1]:
             x, y = x[:-1], y[:-1]
         stripped.append([x, y])
+    start_coords = [_normalize_coord_entry(e) for e in raw.get('start_coords', [])]
+    end_coords = [_normalize_coord_entry(e) for e in raw.get('end_coords', [])]
     return Contour(
         contours=stripped,
         measurements=Measurements(**raw.get('measurements', {})),
         closed=raw.get('closed', []),
-        start_coords=raw.get('start_coords', []),
-        end_coords=raw.get('end_coords', []),
+        start_coords=start_coords,
+        end_coords=end_coords,
     )
 
 

--- a/src/version.py
+++ b/src/version.py
@@ -1,2 +1,2 @@
-__version__ = '1.3.1'
+__version__ = '1.3.2'
 version_file_str = '_'.join(__version__.split('.'))  # version format suitable to be used in filenames


### PR DESCRIPTION
## Pull Request Checklist

- [ ] I have added tests that prove the fix is effective or that the feature works.
- [ ] I ran `pytest` (or `nox` / your CI command) locally and all tests pass.
- [x] I updated `CHANGELOG.md` (or NEWS) and bumped the package version if applicable.
- [x] I added/updated documentation (README, docstrings, or docs).
- [ ] This PR is linked to an issue: fixes #<issue-number> (if applicable).

### What changed
Several start and end coords can now be defined on one contour therefore providing more flexible labeling of frames.

### Why this is useful
it is possible that there are several regions in a vessel where EEM is not visible (e.g. two calcifications on different angles).

### Notes for reviewer
-
